### PR TITLE
fix: Correct parsing of ImpinjPeakRSSI parameter

### DIFF
--- a/internal/llrp/util.go
+++ b/internal/llrp/util.go
@@ -35,7 +35,7 @@ func wordsToHex(src []uint16) string {
 // and hence the returned value is a floats instead of an int.
 func (rt *TagReportData) ExtractRSSI() (float64, bool) {
 	for _, c := range rt.Custom {
-		if c.Is(PENImpinj, ImpinjEnablePeakRSSI) && len(c.Data) == 2 {
+		if c.Is(PENImpinj, ImpinjPeakRSSI) && len(c.Data) == 2 {
 			return float64(int16(binary.BigEndian.Uint16(c.Data))) / 100.0, true // dBm x100
 		}
 	}

--- a/internal/llrp/util_test.go
+++ b/internal/llrp/util_test.go
@@ -125,7 +125,7 @@ func TestExtractRSSI(t *testing.T) {
 		},
 		{
 			name:   "OK - custom",
-			fields: fields{Custom: []Custom{{VendorID: uint32(PENImpinj), Subtype: ImpinjEnablePeakRSSI, Data: []byte{'1', '2'}}}},
+			fields: fields{Custom: []Custom{{VendorID: uint32(PENImpinj), Subtype: ImpinjPeakRSSI, Data: []byte{'1', '2'}}}},
 			want:   float64(int16(binary.BigEndian.Uint16([]byte{'1', '2'}))) / 100.0,
 			want1:  true,
 		},


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/master/.github/Contributing.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Other information

Fixed a typo. `ImpinjEnablePeakRSSI` is what you send to turn on reporting of that value. `ImpinjPeakRSSI` is the actual subtype of the reported parameter. Verified working on my SpeedwayR420 RFID reader.