### PR TITLE
feat(snap): add support for environment variable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
 	local "github.com/edgexfoundry/app-rfid-llrp-inventory/hooks"
 )
 
@@ -47,6 +49,12 @@ func main() {
 		fmt.Println(fmt.Sprintf("edgex-app-rfid-llrp-inventory:configure: initialization failure: %v", err))
 		os.Exit(1)
 
+	}
+
+	log.SetComponentName("configure")
+	if err := options.ProcessAppConfig("app-rfid-llrp-inventory"); err != nil {
+		hooks.Error(fmt.Sprintf("could not process options: %v", err))
+		os.Exit(1)
 	}
 
 	// read env var override configuration

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/app-rfid-llrp-inventory/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/app-rfid-llrp-inventory/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.1.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4
 
 go 1.17

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.1.3 h1:mcV/atn6k6sN6Uik+lSQGEZi4Q6r96epgBW+u6AGZ3Y=
-github.com/canonical/edgex-snap-hooks/v2 v2.1.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4 h1:mbHxD8lIv3ewSUSkwqXj4SEVek2bvw5Nh/+gngInscI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4 h1:mbHxD8lIv3ewSUSkwqXj4SEVek2bvw5Nh/+gngInscI=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5 h1:EDFjmHy8CG4T8uFPqD+Per8Hgk250PvRsMgEDCXjYtE=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
For details on the new scheme for setting environment variables, please refer to https://github.com/edgexfoundry/edgex-go/pull/3986.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?): https://github.com/canonical/edgex-snap-testing/pull/53
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->


1. Set up:
```
snap install edgexfoundry --edge
snap install edgex-app-rfid-llrp-inventory --channel=edge/pr-74
```

2. Enable config and set a global config value:
```
$ snap set edgex-app-rfid-llrp-inventory config-enabled=true
$ snap set edgex-app-rfid-llrp-inventory config.service-startupmsg="testing injection"

$ snap start edgex-app-rfid-llrp-inventory
Started.

$ snap logs -n=all edgex-app-rfid-llrp-inventory | grep "testing injection"
2022-04-25T16:28:59+02:00 edgex-app-rfid-llrp-inventory.app-rfid-llrp-inventory[429579]: level=INFO ts=2022-04-25T14:28:59.224445693Z app=app-rfid-llrp-inventory source=variables.go:352 msg="Variables override of 'Service.StartupMsg' by environment variable: SERVICE_STARTUPMSG=testing injection"
2022-04-25T16:28:59+02:00 edgex-app-rfid-llrp-inventory.app-rfid-llrp-inventory[429579]: level=INFO ts=2022-04-25T14:28:59.323556738Z app=app-rfid-llrp-inventory source=service.go:184 msg="testing injection"
```

3. Set a app-specific value:
```
$ snap set edgex-app-rfid-llrp-inventory apps.app-rfid-llrp-inventory.config.service-port=11111

$ snap restart edgex-app-rfid-llrp-inventory
Restarted.

$ snap logs -n=all edgex-app-rfid-llrp-inventory | grep "11111"
2022-04-25T16:31:05+02:00 edgex-app-rfid-llrp-inventory.app-rfid-llrp-inventory[430015]: level=INFO ts=2022-04-25T14:31:05.094926172Z app=app-rfid-llrp-inventory source=variables.go:352 msg="Variables override of 'Service.Port' by environment variable: SERVICE_PORT=11111"
2022-04-25T16:31:05+02:00 edgex-app-rfid-llrp-inventory.app-rfid-llrp-inventory[430015]: level=INFO ts=2022-04-25T14:31:05.198346026Z app=app-rfid-llrp-inventory source=server.go:156 msg="Starting HTTP Web Server on address localhost:11111"
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->