### PR TITLE
feat!: Consume additional level in event publish topic

### DIFF
--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -100,8 +100,8 @@ Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
   [MessageBus.Topics]
-  SubscribeTopics = "edgex/events/#/#/#/ROAccessReport,edgex/events/#/#/#/ReaderEventNotification"
-  PublishTopic="edgex/events/device/{profilename}/{devicename}/{sourcename}" # publish to same topic format the Device Services use
+  SubscribeTopics = "edgex/events/+/device-rfid-llrp/+/+/ROAccessReport,edgex/events/+/device-rfid-llrp/+/+/ReaderEventNotification"
+  PublishTopic="edgex/events/device/app-rfid-llrp/{profilename}/{devicename}/{sourcename}" # publish to same topic format the Device Services use
   [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="app-rfid-llrp-inventory"


### PR DESCRIPTION
BREAKING CHANGE: Inventory events are published using topic which includes additional level for the `app-rfid-llrp` service name.

Depended on https://github.com/edgexfoundry/device-sdk-go/pull/1313 propagated to Device services, specifically Device RFID LLRP.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  Handled by other PR

## Testing Instructions
Builds service from this branch
Run with LLRP Device service
Verify events are consumed from the device service and new Inventory events are publish on proper topic.
- Validation of topic can be done using Redis CLI and subscribing to expected topic.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->