### PR TITLE
fix: Add missing Service.Host

### DIFF
--- a/res/configuration.yaml
+++ b/res/configuration.yaml
@@ -2,28 +2,28 @@ Writable:
   LogLevel: INFO
 
 Service:
+  Host: localhost
   Port: 59711
   StartupMsg: "RFID LLRP Inventory Service"
 
 Clients:
   core-command:
     UseMessageBus: true
-  # core-metadata:
-  #   Host: "localhost"
+#  core-metadata:
+#    Host: "localhost"
 
 # uncomment when running from command-line in hybrid mode with -cp -o flags
-# Registry:
-#   Host: "localhost"
-# Database:
-#   Host: "localhost" 
+#Registry:
+#  Host: "localhost"
+#Database:
+#  Host: "localhost"
 
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
+#  Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: app-rfid-llrp-inventory
 
 Trigger:
-  Type: edgex-messagebus
   SubscribeTopics: events/+/device-rfid-llrp/+/+/ROAccessReport,edgex/events/+/device-rfid-llrp/+/+/ReaderEventNotification
   PublishTopic: events/device/app-rfid-llrp/{profilename}/{devicename}/{sourcename} # publish to same topic format the Device Services use
 


### PR DESCRIPTION
Also removed un-needed Trigger.Type which is set in Common Config and adjust the spaces on the commented out Host setting so they are indented properly when un-commented.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
run non-secure EdgeX stack
run make build
run with -cp -o -r
Verify the following is not in the log file:
```
"could not register service with Registry: unable to register service with consul: Service information not set"
```
Service is expected to fail when running command line with -r flag due to getting Core Metadata URL from registry, which is for docker.
```
"failed to get existing device names for device service name device-rfid-llrp: failed to se
nd a http request -> Get \"http://edgex-core-metadata:59881/api/v2/device/service/name/device-rfid-llrp?limit=-1&offset=0\": dial tcp: lookup edgex-core-metadata on 8.8.8.8:53: no such 
host" msg="App initialization failed"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->