### PR TITLE
fix: Update v2 links to v3 links in static html page

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
 - **`InventoryEventArrived`**
 ```json
 {
-  "apiVersion": "v2",
+  "apiVersion": "v3",
   "id": "6def8859-5a12-4c83-b68c-256303146682",
   "deviceName": "app-rfid-llrp-inventory",
   "profileName": "app-rfid-llrp-inventory",
@@ -58,7 +58,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
   "origin": 1598043284109799400,
   "readings": [
     {
-      "apiVersion": "v2",
+      "apiVersion": "v3",
       "id": "8d15d035-402f-4abc-85fc-a7ed7213122a",
       "origin": 1598043284109799400,
       "deviceName": "app-rfid-llrp-inventory",
@@ -74,7 +74,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
 - **`InventoryEventMoved`**
 ```json
 {
-  "apiVersion": "v2",
+  "apiVersion": "v3",
   "id": "c78c304e-1906-4d17-bf26-5075756a231f",
   "deviceName": "app-rfid-llrp-inventory",
   "profileName": "app-rfid-llrp-inventory",
@@ -82,7 +82,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
   "origin": 1598401259697580500,
   "readings": [
     {
-      "apiVersion": "v2",
+      "apiVersion": "v3",
       "id": "323694d9-1a48-417a-9f43-25998536ae8f",
       "origin": 1598401259697580500,
       "deviceName": "app-rfid-llrp-inventory",
@@ -98,7 +98,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
 - **`InventoryEventDeparted`**
 ```json
 {
-  "apiVersion": "v2",
+  "apiVersion": "v3",
   "id": "4d042708-c5de-41fa-827a-3f24b364c6de",
   "deviceName": "app-rfid-llrp-inventory",
   "profileName": "app-rfid-llrp-inventory",
@@ -106,7 +106,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
   "origin": 1598062424894043600,
   "readings": [
     {
-      "apiVersion": "v2",
+      "apiVersion": "v3",
       "id": "928ff90d-02d1-43be-81a6-a0d75886b0e4",
       "origin": 1598062424894043600,
       "deviceName": "app-rfid-llrp-inventory",
@@ -116,7 +116,7 @@ Here are some example `EdgeX Events` with accompanying `EdgeX Readings`.
       "value": "{\"epc\":\"30340bb6884cb101a13bc744\",\"tid\":\"\",\"timestamp\":1598062424893,\"last_read\":1598062392524,\"last_known_location\":\"SpeedwayR-10-EF-25_1\"}"
     },
     {
-      "apiVersion": "v2",
+      "apiVersion": "v3",
       "id": "abfff90d-02d1-43be-81a6-a0d75886cdaf",
       "origin": 1598062424894043600,
       "deviceName": "rfid-llrp-inventory",
@@ -278,10 +278,10 @@ application has a format of `<deviceName>_<antennaId>` e.g.
 `Reader-10-EF-25_1` where `Reader-10-EF-25` is the deviceName and `1` is the antennaId.
 
 To get the list of LLRP devices or readers connected,
-`GET` to the `/api/v2/readers` endpoint:   
+`GET` to the `/api/v3/readers` endpoint:   
                                                        
 
-    curl -o- localhost:59711/api/v2/readers
+    curl -o- localhost:59711/api/v3/readers
 
 ```json
 {
@@ -364,9 +364,9 @@ can be done regardless of whether `configuration.yaml` specified initial aliases
 
 Everytime the user creates/updates the Aliases folder, the configuration changes apply to the application dynamically, and the updated alias can be seen under tag location `(location_alias)`
 
-`GET` to the `/api/v2/inventory/snapshot` endpoint:   
+`GET` to the `/api/v3/inventory/snapshot` endpoint:   
                                                        
-    curl -o- localhost:59711/api/v2/inventory/snapshot
+    curl -o- localhost:59711/api/v3/inventory/snapshot
 
 ```json
  [
@@ -457,16 +457,16 @@ Here's how the service works with Behaviors:
 To start all Readers reading with the current behavior, 
 `POST` to the `/command/reading/start` endpoint:
 
-    curl -o- -X POST localhost:59711/api/v2/command/reading/start
+    curl -o- -X POST localhost:59711/api/v3/command/reading/start
 
 To stop reading,
 `POST` to the `/command/reading/stop` endpoint:
 
-    curl -o- -X POST localhost:59711/api/v2/command/reading/stop
+    curl -o- -X POST localhost:59711/api/v3/command/reading/stop
 
 To view the `default` Behavior:
 
-    curl -o- localhost:59711/api/v2/behaviors/default
+    curl -o- localhost:59711/api/v3/behaviors/default
 
 ```json
 {
@@ -487,7 +487,7 @@ The following example uses `jq` to generate the `JSON` Behavior structure,
 the details of which are explained below.
 This particular Behavior enables a `Fast` scan at `30 dBm`:
 
-    curl -o- localhost:59711/api/v2/behaviors/default -XPUT \
+    curl -o- localhost:59711/api/v3/behaviors/default -XPUT \
         --data @<(jq -n '{ScanType: "Fast", Power: {Max: 3000}}')
 
 
@@ -495,7 +495,7 @@ If you attempt to set the Behavior to something that can't be supported
 all the Readers to which it should apply, 
 you'll receive an error response, and the Behavior won't change:
 
-    curl -o- -XPUT localhost:59711/api/v2/behaviors/default \
+    curl -o- -XPUT localhost:59711/api/v3/behaviors/default \
         --data @<(jq -n '{ScanType: "Fast"}')
     
     new behavior is invalid for "Speedway": target power (0.00 dBm)
@@ -622,7 +622,7 @@ with a `set` that targets that `deviceResource`.
 
 When this service sees an Impinj device, 
 it sends a `PUT` request with `{"ImpinjCustomExtensionMessage": "AAAAAA=="}` 
-to `{deviceService}/api/v2/commands/{deviceName}/enableImpinjExt`;
+to `{deviceService}/api/v3/commands/{deviceName}/enableImpinjExt`;
 if that `deviceCommand` and `deviceResource` exist,
 the Device Service will send a `CustomMessage` to the reader,
 enabling this service to send Impinj's `CustomParameter`s.

--- a/static/html/index.html
+++ b/static/html/index.html
@@ -74,7 +74,7 @@
         }
 
         function setBehavior(behavior) {
-          call('PUT', 'api/v2/behaviors/default', JSON.stringify(behavior));
+          call('PUT', 'api/v3/behaviors/default', JSON.stringify(behavior));
           log(JSON.stringify(behavior, null, 2), behavior);
         }
 
@@ -118,16 +118,16 @@
 </nav>
 
 <div id="content" style="height: 100%">
-  <div class="b"><button type="button" class="btn btn-primary" onclick="call('POST', 'http://localhost:59989/api/v2/discovery')">Discover Readers</button></div>
-  <div class="b"><button type="button" class="btn btn-primary" onclick="call('GET', '/api/v2/readers')">List Readers</button></div>
-  <div class="b"><button type="button" class="btn btn-primary" onclick="call('GET', '/api/v2/behaviors/default')">Show Default Behavior</button></div>
+  <div class="b"><button type="button" class="btn btn-primary" onclick="call('POST', 'http://localhost:59989/api/v3/discovery')">Discover Readers</button></div>
+  <div class="b"><button type="button" class="btn btn-primary" onclick="call('GET', '/api/v3/readers')">List Readers</button></div>
+  <div class="b"><button type="button" class="btn btn-primary" onclick="call('GET', '/api/v3/behaviors/default')">Show Default Behavior</button></div>
   <div class="b"><button type="button" class="btn btn-primary" onclick="setDeepScan()">Set Deep Scan Behavior</button></div>
   <div class="b"><button type="button" class="btn btn-primary" onclick="setNormalScan()">Set Normal Scan Behavior</button></div>
   <div class="b"><button type="button" class="btn btn-primary" onclick="setFastScan()">Set Fast Scan Behavior</button></div>
-  <div class="b"><button type="button" class="btn btn-success" onclick="call('POST', '/api/v2/command/reading/start')">Start Reading</button></div>
-  <div class="b"><button type="button" class="btn btn-danger" onclick="call('POST', '/api/v2/command/reading/stop')">Stop Reading</button></div>
-  <div class="b"><button type="button" class="btn btn-light" onclick="call('GET', '/api/v2/inventory/snapshot')">Inventory Snapshot</button></div>
-  <div class="b"><a href="http://localhost:59880/api/v2/event/device/name/app-rfid-llrp-inventory?offset=0&limit=100" target="_blank"><button type="button" class="btn btn-light">EdgeX Inventory Events</button></a></div>
+  <div class="b"><button type="button" class="btn btn-success" onclick="call('POST', '/api/v3/command/reading/start')">Start Reading</button></div>
+  <div class="b"><button type="button" class="btn btn-danger" onclick="call('POST', '/api/v3/command/reading/stop')">Stop Reading</button></div>
+  <div class="b"><button type="button" class="btn btn-light" onclick="call('GET', '/api/v3/inventory/snapshot')">Inventory Snapshot</button></div>
+  <div class="b"><a href="http://localhost:59880/api/v3/event/device/name/app-rfid-llrp-inventory?offset=0&limit=100" target="_blank"><button type="button" class="btn btn-light">EdgeX Inventory Events</button></a></div>
 
   <div id="output_log">
   </div>


### PR DESCRIPTION
closes: #197

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)N/A
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
1. run `make test`
2.  start edgex with device-rfid-llrp 
3. connect device simulator to device-rfid-llrp
4. run `make build` for app-rfid-llrp-inventory
5.  run `./app-rfid-llrp-inventory -cp -o -dev `
6. go to `http://localhost:59711` in browser
7. test all  ui button on page
8. verify response are working and valid

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->