### PR TITLE
fix: Move API document files from openapi/v3 to openapi

### DIFF
--- a/openapi/app-rfid-llrp-inventory.yaml
+++ b/openapi/app-rfid-llrp-inventory.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: EdgeX App RFID LLRP Inventory Service
   description: EdgeX App RFID LLRP Inventory Service REST APIs
-  version: 3.1.0
+  version: 4.0.0
 servers:
 - url: http://localhost:59711
   description: Local running instance of App RFID LLRP Inventory Service


### PR DESCRIPTION
Related to https://github.com/edgexfoundry/edgex-go/issues/4978

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->